### PR TITLE
fix: check db responds to show tables as a health check

### DIFF
--- a/mysql.star
+++ b/mysql.star
@@ -51,6 +51,6 @@ def run_sql(plan, database, sql_query):
         recipe = ExecRecipe(command = ["sh", "-c", "mysql -u {} -p{} -e '{}' {}".format(database.user, database.password, sql_query, database.name)]),
         field = "code",
         assertion = "==",
-        target_vaue = 0
+        target_value = 0
     )
     return exec_result["output"]

--- a/mysql.star
+++ b/mysql.star
@@ -46,11 +46,8 @@ def create_database(plan, database_name, database_user, database_password, seed_
 
 
 def run_sql(plan, database, sql_query):
-    exec_result = plan.wait(
+    exec_result = plan.exec(
         service_name = database.service.name,
         recipe = ExecRecipe(command = ["sh", "-c", "mysql -u {} -p{} -e '{}' {}".format(database.user, database.password, sql_query, database.name)]),
-        field = "code",
-        assertion = "==",
-        target_value = 0
     )
     return exec_result["output"]

--- a/mysql.star
+++ b/mysql.star
@@ -37,6 +37,19 @@ def create_database(plan, database_name, database_user, database_password, seed_
         target_value = 0,
         timeout = "30s",
     )
+
+    # test a generic query works
+    test_query = "show tables"
+    plan.wait(
+        service_name = service_name,
+        recipe = ExecRecipe(command = ["sh", "-c", "mysql -u {} -p{} -e '{}' {}".format(database_user, database_password, test_query, database_name)]),
+        field = "code",
+        assertion = "==",
+        target_value = 0,
+        timeout = "30s",
+    )
+
+
     return struct(
         service=mysql_service,
         name=database_name,

--- a/mysql.star
+++ b/mysql.star
@@ -46,8 +46,11 @@ def create_database(plan, database_name, database_user, database_password, seed_
 
 
 def run_sql(plan, database, sql_query):
-    exec_result = plan.exec(
+    exec_result = plan.wait(
         service_name = database.service.name,
         recipe = ExecRecipe(command = ["sh", "-c", "mysql -u {} -p{} -e '{}' {}".format(database.user, database.password, sql_query, database.name)]),
+        field = "code",
+        assertion = "==",
+        target_vaue = 0
     )
     return exec_result["output"]


### PR DESCRIPTION
i have seen failures where the exit code isn't 0 and I think that happens when mysql isn't fully setup (race condition)

tested this by copying over blog-mysql-seed script & sql scripts from awesome